### PR TITLE
Investigate the StandardScaler for Adult dataset

### DIFF
--- a/utils/dataloading.py
+++ b/utils/dataloading.py
@@ -53,12 +53,12 @@ def load_adult_data(args):
     # train_data = TensorDataset(train_x, train_s, train_y)
     # test_data = TensorDataset(test_x, test_s, test_y)
 
-    scaler = StandardScaler()
+    # scaler = StandardScaler()
 
-    train_scaled = pd.DataFrame(scaler.fit_transform(train_tuple.x), columns=train_tuple.x.columns)
-    train_tuple = DataTuple(x=train_scaled, s=train_tuple.s, y=train_tuple.y)
-    test_scaled = pd.DataFrame(scaler.transform(test_tuple.x), columns=test_tuple.x.columns)
-    test_tuple = DataTuple(x=test_scaled, s=test_tuple.s, y=test_tuple.y)
+    # train_scaled = pd.DataFrame(scaler.fit_transform(train_tuple.x), columns=train_tuple.x.columns)
+    # train_tuple = DataTuple(x=train_scaled, s=train_tuple.s, y=train_tuple.y)
+    # test_scaled = pd.DataFrame(scaler.transform(test_tuple.x), columns=test_tuple.x.columns)
+    # test_tuple = DataTuple(x=test_scaled, s=test_tuple.s, y=test_tuple.y)
 
     train_data = TensorDataset(*[torch.tensor(df.values, dtype=torch.float32) for df in train_tuple])
     test_data = TensorDataset(*[torch.tensor(df.values, dtype=torch.float32) for df in test_tuple])


### PR DESCRIPTION
When this Scalar is active, the validation loss decouples from the training loss and goes to infinity. I observed that after 8 or 12 epoch the validation loss is at infinity. The training loss is fine though and is going down, as one would expect.

Why is this the case?