### PR TITLE
logging the images during evaluation

### DIFF
--- a/finn/run.py
+++ b/finn/run.py
@@ -66,9 +66,13 @@ def log_metrics(args, experiment, model, discs, data):
     evaluate_representations(args, experiment, task_train_repr['all_z'], task_repr['all_z'],
                              predict_y=True, use_fair=True, use_unfair=True)
     evaluate_representations(args, experiment, task_train_repr['recon_y'], task_repr['recon_y'],
-                             predict_y=True, use_x=True, use_fair=True)
+                             predict_y=True, use_x=True, use_fair=True, use_s=True)
     evaluate_representations(args, experiment, task_train_repr['recon_s'], task_repr['recon_s'],
-                             predict_y=True, use_x=True, use_unfair=True)
+                             predict_y=True, use_x=True, use_unfair=True, use_s=True)
+
+    # Grayscale the fair representation
+    evaluate_representations(args, experiment, task_train_repr['recon_y'], task_repr['recon_y'],
+                             predict_y=True, use_x=True, use_fair=True)
 
     # ===========================================================================
     if check_originals:

--- a/finn/train.py
+++ b/finn/train.py
@@ -231,7 +231,7 @@ def main(args, datasets, metric_callback):
         args.disc_lr = args.lr
 
     disc_optimizer = Adam(discs.parameters(), lr=ARGS.disc_lr, weight_decay=ARGS.weight_decay)
-    scheduler =  ExponentialLR(optimizer, gamma=args.gamma)
+    scheduler = ExponentialLR(optimizer, gamma=args.gamma)
                 #ReduceLROnPlateau(optimizer, factor=0.1, patience=ARGS.patience,
                 #                  min_lr=1.e-7, cooldown=1)
 

--- a/finn/utils/evaluate_utils.py
+++ b/finn/utils/evaluate_utils.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from finn.utils.eval_metrics import evaluate_with_classifier
 from finn.utils.training_utils import (train_and_evaluate_classifier, encode_dataset,
-                                       pytorch_data_to_dataframe)
+                                       pytorch_data_to_dataframe, log_images)
 
 
 class MetaDataset(NamedTuple):
@@ -173,7 +173,7 @@ def evaluate_representations(args, experiment, train_data, test_data, predict_y=
 
     if args.dataset == 'cmnist':
         if use_x:
-            clf = train_and_evaluate_classifier(args, train_data, pred_s=not predict_y, use_s=use_s)
+            clf = train_and_evaluate_classifier(args, experiment, train_data, pred_s=not predict_y, use_s=use_s, name=name)
         else:
             clf = evaluate_with_classifier(args, train_data, test_data, in_channels=in_channels, pred_s= not predict_y, use_s=use_s, applicative=True)
         preds_x, test_x = clf(test_data=train_data)

--- a/finn/utils/training_utils.py
+++ b/finn/utils/training_utils.py
@@ -192,7 +192,7 @@ def classifier_training_loop(args, model, train_data, val_data, use_s=True,
     return model
 
 
-def train_and_evaluate_classifier(args, data, pred_s, use_s, model=None):
+def train_and_evaluate_classifier(args, experiment, data, pred_s, use_s, model=None, name=None):
 
     # LOGGER = utils.get_logger(logpath=save_dir / 'logs', filepath=Path(__file__).resolve())
     #
@@ -217,10 +217,10 @@ def train_and_evaluate_classifier(args, data, pred_s, use_s, model=None):
                                      pred_s=pred_s)
 
     return partial(evaluate, args=args, model=model, batch_size=args.test_batch_size,
-                   device=args.device, pred_s=pred_s, use_s=use_s)
+                   device=args.device, pred_s=pred_s, use_s=use_s, experiment=experiment, name=name)
 
 
-def evaluate(args, test_data, model, batch_size, device, pred_s=False, use_s=True, using_x=True):
+def evaluate(args, test_data, model, batch_size, device, pred_s=False, use_s=True, using_x=True, experiment=None, name=None):
     """
     Evaluate a model on a given test set and return the predictions
 
@@ -257,6 +257,9 @@ def evaluate(args, test_data, model, batch_size, device, pred_s=False, use_s=Tru
                 x = torch.cat((x, s), dim=1)
             elif args.dataset == 'cmnist' and not use_s and using_x:
                 x = x.mean(dim=1, keepdim=True)
+            if experiment is not None and args.dataset == 'cmnist':
+                log_images(experiment, x, f"evaluation on {name}")
+
 
             preds = model(x).argmax(dim=1)
             all_preds.extend(preds.detach().cpu().numpy())


### PR DESCRIPTION
Wanted to experiment with grayscaling the fair image post reconstruction. Realised we should probably log the validation images as that might give us an insight into any discrepancies in performance